### PR TITLE
xxtui 待办推送插件（v0.1.4-beta）新增插件通信 API 并优化多 Key 管理体验

### DIFF
--- a/public/plugins/xxtui-todo-push/manifest.json
+++ b/public/plugins/xxtui-todo-push/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "xxtui-todo-push",
   "name": "xxtui 待办推送（beta）",
-  "version": "0.1.3-beta",
+  "version": "0.1.4-beta",
   "minHostVersion": "0.3.6",
   "author": "flyMD",
   "description": "扫描当前文档中的未完成待办并推送到 xxtui（beta）",


### PR DESCRIPTION
- 新增插件通信 API：对外提供 3 个标准 API（pushToXxtui、createReminder、parseAndCreateReminders），供 AI
  助手等其他插件调用，实现跨插件消息推送和提醒创建
- 渠道配置独立化：将 channel 从全局配置移至每个 API Key 的属性中，支持不同 Key 配置不同推送渠道
- Key 选择器弹窗：新增可视化 Key 选择弹窗，替代原有的嵌套菜单，用户可在弹窗中选择 Key
和推送类型（全部/已完成/未完成）
- 备注字段必填：强制要求每个 API Key 配置备注，避免多 Key 场景下的混淆
- 设置面板优化：
  - 面板宽度从 420px 增至 600px，改善多 Key 管理体验
  - 新增 5 列网格布局（Key | 备注 | 渠道 | 默认 | 删除）
  - 新增插件 API 使用说明文档