### PR TITLE
feat(xxtui-todo-push): 可配置回写标记并重构设置面板导航

### DIFF
--- a/public/plugins/xxtui-todo-push/manifest.json
+++ b/public/plugins/xxtui-todo-push/manifest.json
@@ -1,10 +1,10 @@
 {
   "id": "xxtui-todo-push",
-  "name": "xxtui 待办推送（beta）",
-  "version": "0.1.7-beta",
+  "name": "xxtui 待办推送",
+  "version": "0.1.8",
   "minHostVersion": "0.3.6",
   "author": "flyMD",
-  "description": "解析选中文本的待办事项并推送到 xxtui，支持通过微信公众号获取 API Key（beta）",
+  "description": "解析选中文本的待办事项并推送到 xxtui，支持通过微信公众号获取 API Key",
   "homepage": "https://github.com/flyhunterl/flymd",
   "main": "main.js"
 }


### PR DESCRIPTION
  - 设置面板重构为左右分栏导航（推送设置/插件设置/文档/插件 API），固定尺寸 720×620；样式更新。
  - 推送设置：API Key 列表删除按钮改为无边框“×”；来源字段保留。
  - 插件设置：增加“是否回写标记”开关及自定义标记文本（推送标记、创建提醒标记，默认 [pushed] / [reminded]），关闭开
    关时标记输入自动禁用并置灰；保留“重置转换提示”按钮。
  - 标记逻辑：解析与写回均读取自定义标记文本；写回带配置透传；默认行为不变。
  - 推送/提醒流程：默认跳过已标记，弹窗复选框“强制推送/创建”控制是否包含；若全为已标记给出精简提示。
  - 交互提示：所有确认弹窗标题改为“提示”；无有效时间时改用弹窗提示。
  - 其他：保持回写行尾精准定位和禁用时不写回。