### PR TITLE
feat(editor-enhancer): 新增“用...包裹”右键菜单与模板变量支持

### DIFF
--- a/public/plugins/editor-enhancer/manifest.json
+++ b/public/plugins/editor-enhancer/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "editor-enhancer",
   "name": "编辑器增强",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "xxtui",
   "description": "编辑器增强：在空行输入“/”启用指令，快速插入内容",
   "i18n": {


### PR DESCRIPTION
本次更新升级 editor-enhancer 至 0.1.1，新增“用...包裹”右键菜单与独立设置页，支持自定义包裹模板并提供 {{selection}} / {{cursor}} / {{date}} / {{time}} / {{datetime}} 变量；Slash 菜单补充 /datetime 内置指令，完善弹窗/交互细节与 i18n 文案。