### PR TITLE
feat(editor-enhancer): 更新 Slash/包裹代码块指令并升级到 0.1.2

### DIFF
--- a/public/plugins/editor-enhancer/main.js
+++ b/public/plugins/editor-enhancer/main.js
@@ -114,15 +114,24 @@ const BUILTIN_ITEMS = [
         templateZh: '| 列1 | 列2 |\n| --- | --- |\n|     |     |',
         templateEn: '| Col 1 | Col 2 |\n| --- | --- |\n|     |     |',
     },
-    {
-        id: 'builtin-code',
-        category: 'blocks',
-        labelZh: '代码块',
-        labelEn: 'Code Block',
-        trigger: '/code',
-        templateZh: '```\n{{cursor}}\n```',
-        templateEn: '```\n{{cursor}}\n```',
-    },
+  {
+    id: 'builtin-code',
+    category: 'blocks',
+    labelZh: '代码块',
+    labelEn: 'Code Block',
+    trigger: '/codeblock',
+    templateZh: '```\n{{cursor}}\n```',
+    templateEn: '```\n{{cursor}}\n```',
+  },
+  {
+    id: 'builtin-fence',
+    category: 'blocks',
+    labelZh: '围栏代码块',
+    labelEn: 'Fenced Code Block',
+    trigger: '/fence',
+    templateZh: '~~~\n{{cursor}}\n~~~',
+    templateEn: '~~~\n{{cursor}}\n~~~',
+  },
     {
         id: 'builtin-h1',
         category: 'basic',
@@ -380,6 +389,13 @@ const SURROUND_BUILTIN_ITEMS = [
     labelZh: '代码块',
     labelEn: 'Code Block',
     template: '```\n{{selection}}\n```',
+  },
+  {
+    id: 'surround-fenced-code-block',
+    category: 'blocks',
+    labelZh: '围栏代码块',
+    labelEn: 'Fenced Code Block',
+    template: '~~~\n{{selection}}\n~~~',
   },
 ]
 

--- a/public/plugins/editor-enhancer/manifest.json
+++ b/public/plugins/editor-enhancer/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "editor-enhancer",
   "name": "编辑器增强",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "xxtui",
   "description": "编辑器增强：在空行输入“/”启用指令，快速插入内容",
   "i18n": {


### PR DESCRIPTION
本次更新将 editor‑enhancer 版本提升至 0.1.2，Slash 菜单把 /code 改为 /codeblock，新增 /fence（~~~ 围栏代码块）；“用...包裹”内置项补充围栏代码块选项。