### PR TITLE
feat(xxtui-todo-push): 新增自定义消息与强制推送标记开关

### DIFF
--- a/public/plugins/xxtui-todo-push/manifest.json
+++ b/public/plugins/xxtui-todo-push/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "xxtui-todo-push",
   "name": "xxtui 待办推送",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "flyMD",
   "description": "解析选中文本的待办事项并推送到 xxtui，支持通过微信公众号获取 API Key",
   "i18n": {


### PR DESCRIPTION
- 新增“自定义消息”页签，支持设置 from / 标题 / 正文
- 支持 $title / $content 模板替换，并在渲染后追加来源
- 新增“普通文本推送”类型与分组选择 UI
- 新增“强制推送保留尾标记”开关（默认去除）
- 左侧菜单文案优化：API Key 管理 / 自定义消息