### PR TITLE
feat: support LaTeX standard delimiters \(...\) and \[...\]

### DIFF
--- a/src/plugins/markdownItKatex.ts
+++ b/src/plugins/markdownItKatex.ts
@@ -17,44 +17,97 @@ function isValidDelim(src: string, pos: number) {
 }
 
 function math_inline(state: any, silent: boolean) {
-  if (state.src[state.pos] !== '$') return false
-  const res = isValidDelim(state.src, state.pos)
-  if (!res.canOpen) { if (!silent) state.pending += '$'; state.pos += 1; return true }
-  let start = state.pos + 1
-  let match = start
-  while ((match = state.src.indexOf('$', match)) !== -1) {
+  let start, match, res, token, markup, closeMarkup
+
+  if (state.src[state.pos] === '$') {
+    markup = '$'
+    closeMarkup = '$'
+  } else if (state.src.slice(state.pos, state.pos + 2) === '\\(') {
+    markup = '\\('
+    closeMarkup = '\\)'
+  } else {
+    return false
+  }
+
+  if (markup === '$') {
+    res = isValidDelim(state.src, state.pos)
+    if (!res.canOpen) {
+      if (!silent) state.pending += '$'
+      state.pos += 1
+      return true
+    }
+  }
+
+  start = state.pos + markup.length
+  match = start
+  while ((match = state.src.indexOf(closeMarkup, match)) !== -1) {
     let p = match - 1
     while (state.src[p] === '\\') p--
     if (((match - p) & 1) === 1) break
     match++
   }
-  if (match === -1) { if (!silent) state.pending += '$'; state.pos = start; return true }
-  if (match - start === 0) { if (!silent) state.pending += '$$'; state.pos = start + 1; return true }
-  const res2 = isValidDelim(state.src, match)
-  if (!res2.canClose) { if (!silent) state.pending += '$'; state.pos = start; return true }
-  if (!silent) { const t = state.push('math_inline', 'math', 0); t.markup = '$'; t.content = state.src.slice(start, match) }
-  state.pos = match + 1
+
+  if (match === -1) {
+    if (!silent) state.pending += markup
+    state.pos = start
+    return true
+  }
+
+  if (markup === '$' && match - start === 0) {
+    if (!silent) state.pending += '$$'
+    state.pos = start + 1
+    return true
+  }
+
+  if (markup === '$') {
+    const res2 = isValidDelim(state.src, match)
+    if (!res2.canClose) {
+      if (!silent) state.pending += '$'
+      state.pos = start
+      return true
+    }
+  }
+
+  if (!silent) {
+    token = state.push('math_inline', 'math', 0)
+    token.markup = markup
+    token.content = state.src.slice(start, match)
+  }
+  state.pos = match + closeMarkup.length
   return true
 }
 
 function math_block(state: any, start: number, end: number, silent: boolean) {
   let pos = state.bMarks[start] + state.tShift[start]
   let max = state.eMarks[start]
+
+  let openTag = '$$', closeTag = '$$'
+  if (state.src.slice(pos, pos + 2) === '$$') {
+    // default
+  } else if (state.src.slice(pos, pos + 2) === '\\[') {
+    openTag = '\\['
+    closeTag = '\\]'
+  } else {
+    return false
+  }
+
   if (pos + 2 > max) return false
-  if (state.src.slice(pos, pos + 2) !== '$$') return false
   pos += 2
   let firstLine = state.src.slice(pos, max)
   let next = start, lastLine = '', found = false
   if (silent) return true
-  if (firstLine.trim().slice(-2) === '$$') { firstLine = firstLine.trim().slice(0, -2); found = true }
+  if (firstLine.trim().slice(-2) === closeTag) {
+    firstLine = firstLine.trim().slice(0, -2)
+    found = true
+  }
   for (; !found;) {
     next++
     if (next >= end) break
     pos = state.bMarks[next] + state.tShift[next]
     max = state.eMarks[next]
     if (pos < max && state.tShift[next] < state.blkIndent) break
-    if (state.src.slice(pos, max).trim().slice(-2) === '$$') {
-      const lastPos = state.src.slice(0, max).lastIndexOf('$$')
+    if (state.src.slice(pos, max).trim().slice(-2) === closeTag) {
+      const lastPos = state.src.slice(0, max).lastIndexOf(closeTag)
       lastLine = state.src.slice(pos, lastPos)
       found = true
     }
@@ -65,7 +118,8 @@ function math_block(state: any, start: number, end: number, silent: boolean) {
   token.content = (firstLine && firstLine.trim() ? firstLine + '\n' : '') +
                   state.getLines(start + 1, next, state.tShift[start], true) +
                   (lastLine && lastLine.trim() ? lastLine : '')
-  token.map = [start, state.line]; token.markup = '$$'
+  token.map = [start, state.line]
+  token.markup = openTag
   return true
 }
 

--- a/src/wysiwyg/v2/index.ts
+++ b/src/wysiwyg/v2/index.ts
@@ -2045,7 +2045,20 @@ function enterLatexSourceEdit(hitEl: HTMLElement) {
     const ta = document.createElement('textarea')
     const placeholder = '在此输入Katex公式'
     const displayCode = (isBlock && isNew && !code) ? placeholder : code
-    ta.value = (isBlock ? ('$$\n' + (displayCode || '') + '\n$$') : ('$' + (displayCode || '') + '$'))
+    // 允许编辑器保留原有的定界符，而不是强制转换为 $ / $$
+    if (isBlock) {
+      if (displayCode.trim().startsWith('\\[') && displayCode.trim().endsWith('\\]')) {
+        ta.value = displayCode
+      } else {
+        ta.value = '$$\n' + (displayCode || '') + '\n$$'
+      }
+    } else {
+      if (displayCode.trim().startsWith('\\(') && displayCode.trim().endsWith('\\)')) {
+        ta.value = displayCode
+      } else {
+        ta.value = '$' + (displayCode || '') + '$'
+      }
+    }
     ta.style.width = '100%'
     // 根据公式类型与渲染高度估算一个更宽松的编辑高度，避免复杂公式被挤在两行内
     const baseLines = isBlock ? 4 : 3
@@ -2075,10 +2088,12 @@ function enterLatexSourceEdit(hitEl: HTMLElement) {
       v = String(v || '').trim()
       const isBlk = (mathEl.dataset?.type === 'math_block' || mathEl.tagName === 'DIV')
       if (isBlk) {
-        const m = v.match(/^\s*\$\$\s*[\r\n]?([\s\S]*?)\s*[\r\n]?\$\$\s*$/)
+        // 兼容 $$ 和 \[
+        const m = v.match(/^\s*(?:\$\$|\\\[)\s*[\r\n]?([\s\S]*?)\s*[\r\n]?(?:\$\$|\\\])\s*$/)
         if (m) v = m[1]
       } else {
-        const m = v.match(/^\s*\$([\s\S]*?)\$\s*$/)
+        // 兼容 $ 和 \(
+        const m = v.match(/^\s*(?:\$|\\\()([\s\S]*?)(?:\$|\\\))\s*$/)
         if (m) v = m[1]
       }
       // 更新公式并在块级公式后插入新段落（使用缓存的位置信息）

--- a/src/wysiwyg/v2/index.ts
+++ b/src/wysiwyg/v2/index.ts
@@ -341,9 +341,11 @@ export async function enableWysiwygV2(root: HTMLElement, initialMd: string, onCh
   // 规范化内容：空内容也是合法的（新文档或空文档）
   const content0 = normalizeTabIndentText((initialMd || '').toString())
   const content = maybeConvertHtmlTableBlocksToGfm(content0)
-  // 保护 Excel 公式里的 `$`，避免被 remark-math / 输入规则误识别为行内数学
-  const contentForEditor = protectExcelDollarRefs(content)
-  console.log('[WYSIWYG V2] enableWysiwygV2 called, content length:', content.length)
+  // 保护 Excel 公式里的 `$`，并支持 LaTeX 标准定界符 \( 和 \[
+  let contentForEditor = protectExcelDollarRefs(content)
+  // 为编辑器兼容性：临时将 \( / \[ 转换为 $ / $$ 供 Milkdown 识别（在读取模式下已经原生支持渲染）
+  contentForEditor = contentForEditor.replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$')
+  contentForEditor = contentForEditor.replace(/\\\[([\s\S]*?)\\\]/g, '$$$$$1$$$$')
 
   // 仅销毁旧编辑器与观察器，保留外层传入的 root（避免被移除导致空白）
   cleanupEditorOnly()


### PR DESCRIPTION
This PR adds support for LaTeX standard delimiters \(...\) for inline math and \[...\] for block math.

### Changes:
1. Modified `src/plugins/markdownItKatex.ts` to recognize these delimiters in the markdown-it rendering engine.
2. Updated `src/wysiwyg/v2/index.ts` to ensure the math formula editor preserves these delimiters when editing existing formulas.

This improves compatibility with documents using standard LaTeX math markers.