### PR TITLE
修复 Star History 图表

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -398,7 +398,7 @@ See: [ROADMAP (English)](ROADMAP.en.md)
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=flyhunterl/flymd&type=date&legend=top-left)](https://www.star-history.com/#flyhunterl/flymd&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=flyhunterl/flymd&type=date&legend=top-left)](https://star-history.dera.page/#flyhunterl/flymd&type=date&legend=top-left)
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ FlyMD 拥有丰富的插件生态,支持通过扩展插件无限扩展功能。
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=flyhunterl/flymd&type=date&legend=top-left)](https://www.star-history.com/#flyhunterl/flymd&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=flyhunterl/flymd&type=date&legend=top-left)](https://star-history.dera.page/#flyhunterl/flymd&type=date&legend=top-left)
 
 ### 许可协议
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因接口限制已失效，急需修复。本次变更改用新的数据源，无需 API 令牌即可正常显示，确保图表恢复可用。